### PR TITLE
H1 width fix tablet

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -869,7 +869,7 @@ footer h3 {
 
     .h1smallScreens {
         width: 570px;
-        margin-left: 133px;
+        margin-left: 140px;
     }
 
     h1 {
@@ -882,7 +882,7 @@ footer h3 {
     }
 
     .mainText {
-        margin-left: 133px;
+        margin-left: 140px;
         margin-right: 145px;
         width: 524px;
         margin-bottom: 94px;

--- a/style.scss
+++ b/style.scss
@@ -867,6 +867,11 @@ footer h3 {
         display: none;
     }
 
+    .h1smallScreens {
+        width: 570px;
+        margin-left: 133px;
+    }
+
     h1 {
         width: 550px;
         font-size: 64px;
@@ -877,7 +882,7 @@ footer h3 {
     }
 
     .mainText {
-        margin-left: 165px;
+        margin-left: 133px;
         margin-right: 145px;
         width: 524px;
         margin-bottom: 94px;


### PR DESCRIPTION
ökade bredden på h1an för ipad, så att "välkommen till" står på samma rad (som det för i designen). Minskade även margin-left på h1an och maintext för att få det något mer centrerat